### PR TITLE
Some more cflags tuning

### DIFF
--- a/org.quetoo.Quetoo.yaml
+++ b/org.quetoo.Quetoo.yaml
@@ -71,8 +71,12 @@ modules:
           tag-pattern: ^v([\d.]+)$
 
   - name: Quetoo
+    build-options:
+      env:
+        CFLAGS: ''
     config-opts:
       - --enable-optimizations=expensive
+      - --disable-debug
     sources:
       - type: git
         url: https://github.com/jdolan/quetoo.git


### PR DESCRIPTION
- Clear environment cflags - they contain some flags that hurt performance.

- Disable debug flags - the Flatpak build of Quetoo won't be debugged anyway.